### PR TITLE
fix skip for now link to correct place

### DIFF
--- a/src/styles/Activity.css
+++ b/src/styles/Activity.css
@@ -16,7 +16,7 @@ button {
   height: 3.75rem;
 }
 
-.answerButton > img {
+.answerButton>img {
   flex-basis: 10%;
   height: 3rem;
   width: 3rem;
@@ -43,6 +43,11 @@ button {
 
 .forwardArrow {
   height: 1rem;
+}
+
+.skipSection {
+  display: flex;
+  justify-content: center;
 }
 
 .unselectedAnswerButton {
@@ -73,12 +78,12 @@ button {
   padding-bottom: 2rem;
 }
 
-.QuestionContainer > p {
+.QuestionContainer>p {
   padding-top: 1.5rem;
   padding-bottom: 0.8rem;
 }
 
-.QuestionContainer > img {
+.QuestionContainer>img {
   width: 45.875rem;
   height: 18.75rem;
   flex-shrink: 0;
@@ -109,7 +114,7 @@ img {
   margin: 2rem;
 }
 
-.AnswersContainer > button {
+.AnswersContainer>button {
   display: flex;
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This change fixes the Skip For Now link back to correct place to the center. It was somehow got changed to the left of the page.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link the relevant Jira story card here. -->
[Jira Story Card](https://cbfcamila.atlassian.net/browse/RSST-106)

## Testing
<!--- Please describe in detail how you tested your changes, -->
<!--- and how others can test your changes. -->
Changes can be viewed in the deploy preview after clicking Log in button, mission hub, select trivia, start mission.

## Takeaways
<!--- What did you learn from working on this? -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ x] I have linked the relevant Jira story card and checked that my changes meet the success criteria.
